### PR TITLE
Fixed a client only constructor being used to find rifts

### DIFF
--- a/src/main/java/thecodex6824/thaumicaugmentation/common/tile/TileRiftMoverOutput.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/common/tile/TileRiftMoverOutput.java
@@ -109,7 +109,8 @@ public class TileRiftMoverOutput extends TileEntity implements ITickable, IInter
                 if (jar != null && jar.hasRift()) {
                     Vec3d riftPos = findRiftPos();
                     if (riftPos != null) {
-                        List<EntityFluxRift> rifts = world.getEntitiesWithinAABB(EntityFluxRift.class, new AxisAlignedBB(riftPos, riftPos).grow(32.0F));
+                        List<EntityFluxRift> rifts = world.getEntitiesWithinAABB(EntityFluxRift.class,
+                                new AxisAlignedBB(riftPos.x, riftPos.y, riftPos.z, riftPos.x, riftPos.y, riftPos.z).grow(32.0F));
                         if (rifts.isEmpty()) {
                             rift = new EntityFluxRift(world);
                             EnumFacing facing = world.getBlockState(pos.down()).getValue(IHorizontallyDirectionalBlock.DIRECTION);


### PR DESCRIPTION
Hi, ran into an error on our modded server.
Server was complaining about not being about to find the AxisAlignedBB method, and discovered a client only constructor being used.
I decided to fix it real quick and submit a PR so that the Metaspacial Extruder worked again for us!

Thanks,
Walaryne