### PR TITLE
Fix crash with portal entering

### DIFF
--- a/src/main/java/thecodex6824/thaumicaugmentation/common/world/feature/WorldGenVoidStoneSpike.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/common/world/feature/WorldGenVoidStoneSpike.java
@@ -38,6 +38,12 @@ public class WorldGenVoidStoneSpike extends WorldGenerator {
 
     @Override
     protected void setBlockAndNotifyAdequately(World world, BlockPos pos, IBlockState state) {
+        
+        //Fix java.lang.ArrayIndexOutOfBoundsException: -1
+        if (pos.getY() < 0) {
+            return;
+        }
+        
         world.setBlockState(pos, state, 2 | 16);
     }
     


### PR DESCRIPTION
java.lang.ArrayIndexOutOfBoundsException: -1
	at net.minecraft.world.chunk.Chunk.func_177436_a(Chunk.java:647)
	at net.minecraft.world.World.func_180501_a(World.java:487)
	at net.minecraft.world.gen.feature.WorldGenerator.func_175903_a(WorldGenerator.java:37)
	at thecodex6824.thaumicaugmentation.common.world.feature.WorldGenVoidStoneSpike.func_180709_b(WorldGenVoidStoneSpike.java:80)
	at thecodex6824.thaumicaugmentation.common.world.biome.BiomeDecoratorEmptinessBase.func_180292_a(BiomeDecoratorEmptinessBase.java:42)
	at thecodex6824.thaumicaugmentation.common.world.biome.BiomeDecoratorTaintedLands.func_180292_a(BiomeDecoratorTaintedLands.java:76)
	at net.minecraft.world.biome.Biome.func_180624_a(Biome.java:226)
	at thecodex6824.thaumicaugmentation.common.world.ChunkGeneratorEmptiness.func_185931_b(ChunkGeneratorEmptiness.java:301)
	at net.minecraft.world.chunk.Chunk.func_186034_a(Chunk.java:1233)
	at net.minecraft.world.chunk.Chunk.populateCB(Chunk.java:1203)
	at net.minecraft.world.gen.ChunkProviderServer.func_186025_d(ChunkProviderServer.java:159)
	at net.minecraft.server.management.PlayerChunkMapEntry.func_187268_a(PlayerChunkMapEntry.java:126)
	at net.minecraft.server.management.PlayerChunkMap.func_72693_b(PlayerChunkMap.java:175)
	at net.minecraft.world.WorldServer.func_72835_b(WorldServer.java:295)
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:894)
	at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:474)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:770)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:630)
	at java.lang.Thread.run(Thread.java:748)