### PR TITLE
This should fix impetus connections disconnecting on world load

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,6 +157,8 @@ dependencies {
 idea {
     module {
         inheritOutputDirs = true
+        downloadJavadoc = true
+        downloadSources = true
     }
 }
 

--- a/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/IImpetusNode.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/IImpetusNode.java
@@ -66,7 +66,9 @@ public interface IImpetusNode extends INode<IImpetusGraph, IImpetusNode> {
     public boolean removeInputLocation(DimensionalBlockPos toRemove);
     
     public boolean removeOutputLocation(DimensionalBlockPos toRemove);
-    
+
+    public void shouldTryToReConnect(World world);
+
     public void init(World world);
     
     public void unload();

--- a/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/IImpetusNode.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/IImpetusNode.java
@@ -1,21 +1,21 @@
 /**
- *  Thaumic Augmentation
- *  Copyright (c) 2019 TheCodex6824.
- *
- *  This file is part of Thaumic Augmentation.
- *
- *  Thaumic Augmentation is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Lesser General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Thaumic Augmentation is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with Thaumic Augmentation.  If not, see <https://www.gnu.org/licenses/>.
+ * Thaumic Augmentation
+ * Copyright (c) 2019 TheCodex6824.
+ * <p>
+ * This file is part of Thaumic Augmentation.
+ * <p>
+ * Thaumic Augmentation is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * Thaumic Augmentation is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Thaumic Augmentation.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package thecodex6824.thaumicaugmentation.api.impetus.node;
@@ -30,55 +30,51 @@ import thecodex6824.thaumicaugmentation.api.graph.INode;
 import thecodex6824.thaumicaugmentation.api.util.DimensionalBlockPos;
 
 public interface IImpetusNode extends INode<IImpetusGraph, IImpetusNode> {
-    
+
     public Set<DimensionalBlockPos> getInputLocations();
-    
+
     public Set<DimensionalBlockPos> getOutputLocations();
-    
+
     public default long onTransaction(Deque<IImpetusNode> path, long energy, boolean simulate) {
         return energy;
     }
-    
+
     public DimensionalBlockPos getLocation();
-    
+
     public void setLocation(DimensionalBlockPos location);
-    
+
     public Vec3d getBeamEndpoint();
-    
+
     public boolean shouldPhysicalBeamLinkTo(IImpetusNode other);
-    
+
     public boolean shouldEnforceBeamLimitsWith(IImpetusNode other);
-    
+
     public boolean canConnectNodeAsInput(IImpetusNode toConnect);
-    
+
     public boolean canConnectNodeAsOutput(IImpetusNode toConnect);
-    
+
     public boolean canRemoveNodeAsInput(IImpetusNode toRemove);
-    
+
     public boolean canRemoveNodeAsOutput(IImpetusNode toRemove);
-    
+
     public double getMaxConnectDistance(IImpetusNode toConnect);
-    
+
     public boolean addInputLocation(DimensionalBlockPos toConnect);
-    
+
     public boolean addOutputLocation(DimensionalBlockPos toConnect);
-    
+
     public boolean removeInputLocation(DimensionalBlockPos toRemove);
-    
+
     public boolean removeOutputLocation(DimensionalBlockPos toRemove);
 
-    public boolean hasUnloadedNodes();
-
-    public boolean tryConnectUnloadedNodes(World world);
-
     public void init(World world);
-    
+
     public void unload();
-    
+
     public void destroy();
-    
+
     public NBTTagCompound getSyncNBT();
-    
+
     public void readSyncNBT(NBTTagCompound tag);
-    
+
 }

--- a/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/IImpetusNode.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/IImpetusNode.java
@@ -67,7 +67,7 @@ public interface IImpetusNode extends INode<IImpetusGraph, IImpetusNode> {
     
     public boolean removeOutputLocation(DimensionalBlockPos toRemove);
 
-    public void shouldTryToReConnect(World world);
+    public boolean hasUnloadedNodes(World world);
 
     public void init(World world);
     

--- a/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/IImpetusNode.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/IImpetusNode.java
@@ -67,7 +67,9 @@ public interface IImpetusNode extends INode<IImpetusGraph, IImpetusNode> {
     
     public boolean removeOutputLocation(DimensionalBlockPos toRemove);
 
-    public boolean hasUnloadedNodes(World world);
+    public boolean hasUnloadedNodes();
+
+    public boolean tryConnectUnloadedNodes(World world);
 
     public void init(World world);
     

--- a/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/NodeHelper.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/NodeHelper.java
@@ -243,7 +243,10 @@ public final class NodeHelper {
     public static void validateOutputs(World sharedWorld, IImpetusNode node) {
         HashSet<IImpetusNode> changed = new HashSet<>();
         for (IImpetusNode output : node.getOutputs()) {
-            node.hasUnloadedNodes(sharedWorld);
+            if (node.hasUnloadedNodes()) {
+                node.tryConnectUnloadedNodes(sharedWorld);
+            }
+
             if (sharedWorld.provider.getDimension() == node.getLocation().getDimension() &&
                     sharedWorld.provider.getDimension() == output.getLocation().getDimension()) {
                 

--- a/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/NodeHelper.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/NodeHelper.java
@@ -1,21 +1,21 @@
 /**
- *  Thaumic Augmentation
- *  Copyright (c) 2019 TheCodex6824.
- *
- *  This file is part of Thaumic Augmentation.
- *
- *  Thaumic Augmentation is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Lesser General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Thaumic Augmentation is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with Thaumic Augmentation.  If not, see <https://www.gnu.org/licenses/>.
+ * Thaumic Augmentation
+ * Copyright (c) 2019 TheCodex6824.
+ * <p>
+ * This file is part of Thaumic Augmentation.
+ * <p>
+ * Thaumic Augmentation is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * Thaumic Augmentation is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Thaumic Augmentation.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package thecodex6824.thaumicaugmentation.api.impetus.node;
@@ -52,27 +52,27 @@ import thecodex6824.thaumicaugmentation.api.util.RaytraceHelper;
 
 public final class NodeHelper {
 
-    private NodeHelper() {}
-    
+    private NodeHelper() {
+    }
+
     @SuppressWarnings("null")
-    public static boolean handleLinkInteract(TileEntity provider, World world, ItemStack stack, EntityPlayer player, BlockPos pos, 
-            EnumFacing face, EnumHand hand) {
-        
+    public static boolean handleLinkInteract(TileEntity provider, World world, ItemStack stack, EntityPlayer player, BlockPos pos,
+                                             EnumFacing face, EnumHand hand) {
+
         IImpetusLinker linker = stack.getCapability(CapabilityImpetusLinker.IMPETUS_LINKER, null);
         if (!world.isRemote && linker != null) {
             DimensionalBlockPos origin = linker.getOrigin();
             if (player.isSneaking()) {
                 if (!origin.isInvalid() && origin.getPos().getX() == pos.getX() && origin.getPos().getY() == pos.getY() &&
-                            origin.getPos().getZ() == pos.getZ() && origin.getDimension() == world.provider.getDimension()) {
-                        
+                        origin.getPos().getZ() == pos.getZ() && origin.getDimension() == world.provider.getDimension()) {
+
                     linker.setOrigin(DimensionalBlockPos.INVALID);
                     return true;
                 }
-                
+
                 linker.setOrigin(new DimensionalBlockPos(pos.getX(), pos.getY(), pos.getZ(), world.provider.getDimension()));
                 return true;
-            }
-            else if (!origin.isInvalid()) {
+            } else if (!origin.isInvalid()) {
                 IImpetusNode node = provider.getCapability(CapabilityImpetusNode.IMPETUS_NODE, null);
                 if (!origin.equals(node.getLocation()) && world.isBlockLoaded(origin.getPos())) {
                     TileEntity te = world.getChunk(origin.getPos()).getTileEntity(origin.getPos(), EnumCreateEntityType.CHECK);
@@ -86,8 +86,7 @@ public final class NodeHelper {
                                     te.markDirty();
                                     syncRemovedImpetusNodeInput(node, origin);
                                 }
-                            }
-                            else {
+                            } else {
                                 if (otherNode.getNumOutputs() >= otherNode.getMaxOutputs())
                                     player.sendStatusMessage(new TextComponentTranslation("thaumicaugmentation.text.impetus_link_limit_out"), true);
                                 else if (node.getNumInputs() >= node.getMaxInputs())
@@ -110,23 +109,21 @@ public final class NodeHelper {
                             }
                         }
                     }
-                }
-                else
+                } else
                     player.sendStatusMessage(new TextComponentTranslation("thaumicaugmentation.text.impetus_link_same_pos"), true);
-                    
+
                 return true;
             }
-        }
-        else if (world.isRemote)
+        } else if (world.isRemote)
             return true;
-        
+
         return false;
     }
-    
+
     public static ConsumeResult consumeImpetusFromConnectedProviders(long amount, IImpetusConsumer dest, boolean simulate) {
         if (amount <= 0)
             return new ConsumeResult(0, Collections.emptyMap());
-        
+
         ArrayList<IImpetusProvider> providers = new ArrayList<>(dest.getGraph().findDirectProviders(dest));
         if (!providers.isEmpty()) {
             providers.sort((p1, p2) -> Long.compare(p2.provide(Long.MAX_VALUE, true), p1.provide(Long.MAX_VALUE, true)));
@@ -135,7 +132,7 @@ public final class NodeHelper {
                 for (int i = 0; i < remove; ++i)
                     providers.remove(providers.size() - 1);
             }
-            
+
             ArrayList<Deque<IImpetusNode>> paths = new ArrayList<>(providers.size());
             HashSet<IImpetusProvider> removedProviders = new HashSet<>();
             for (IImpetusProvider p : providers) {
@@ -147,7 +144,7 @@ public final class NodeHelper {
                     removedProviders.add(p);
                 }
             }
-            
+
             providers.removeAll(removedProviders);
             if (providers.size() > 0) {
                 long drawn = 0;
@@ -164,7 +161,7 @@ public final class NodeHelper {
                             if (actuallyDrawn <= 0)
                                 break;
                         }
-                        
+
                         if (actuallyDrawn > 0) {
                             actuallyDrawn = p.provide(actuallyDrawn, simulate);
                             usedPaths.put(nodes, actuallyDrawn);
@@ -172,28 +169,25 @@ public final class NodeHelper {
                             if (actuallyDrawn < step && i < providers.size() - 1) {
                                 step = (amount - drawn) / (providers.size() - (i + 1));
                                 remain = (amount - drawn) % (providers.size() - (i + 1));
-                            }
-                            else
+                            } else
                                 --remain;
-                        }
-                        else if (i < providers.size() - 1) {
+                        } else if (i < providers.size() - 1) {
                             step = (amount - drawn) / (providers.size() - (i + 1));
                             remain = (amount - drawn) % (providers.size() - (i + 1));
                         }
-                    }
-                    else if (i < providers.size() - 1) {
+                    } else if (i < providers.size() - 1) {
                         step = (amount - drawn) / (providers.size() - (i + 1));
                         remain = (amount - drawn) % (providers.size() - (i + 1));
                     }
                 }
-                
+
                 return new ConsumeResult(drawn, usedPaths);
             }
         }
-        
+
         return new ConsumeResult(0, Collections.emptyMap());
     }
-    
+
     public static boolean nodesPassDefaultCollisionCheck(World sharedWorld, IImpetusNode node1, IImpetusNode node2) {
         Vec3d start = node1.getBeamEndpoint();
         Vec3d target = node2.getBeamEndpoint();
@@ -208,8 +202,7 @@ public final class NodeHelper {
                         (state.isOpaqueCube() || state.getLightOpacity(sharedWorld, r.getBlockPos()) > 0)) {
                     clear = false;
                     break;
-                }
-                else {
+                } else {
                     double dX = Math.max(-1, Math.min(1, target.x - r.hitVec.x));
                     double dY = Math.max(-1, Math.min(1, target.y - r.hitVec.y));
                     double dZ = Math.max(-1, Math.min(1, target.z - r.hitVec.z));
@@ -217,10 +210,10 @@ public final class NodeHelper {
                 }
             }
         }
-        
+
         return clear;
     }
-    
+
     public static void validateFullGraph(IImpetusGraph graph) {
         // check for nodes with invalid links
         // i.e. an input with no corresponding output, or the other way around
@@ -230,19 +223,19 @@ public final class NodeHelper {
                 if (!input.hasOutput(node))
                     toRemove.add(input);
             }
-            
+
             for (IImpetusNode n : toRemove)
                 node.removeInput(n);
-            
+
             toRemove.clear();
             for (IImpetusNode output : node.getOutputs()) {
                 if (!output.hasInput(node))
                     toRemove.add(output);
             }
-            
+
             for (IImpetusNode n : toRemove)
                 node.removeOutput(n);
-            
+
             toRemove.clear();
         }
     }
@@ -250,6 +243,7 @@ public final class NodeHelper {
     public static void validateOutputs(World sharedWorld, IImpetusNode node) {
         HashSet<IImpetusNode> changed = new HashSet<>();
         for (IImpetusNode output : node.getOutputs()) {
+            node.shouldTryToReConnect(sharedWorld);
             if (sharedWorld.provider.getDimension() == node.getLocation().getDimension() &&
                     sharedWorld.provider.getDimension() == output.getLocation().getDimension()) {
                 
@@ -270,7 +264,7 @@ public final class NodeHelper {
                 }
             }
         }
-        
+
         for (IImpetusNode n : changed) {
             if (n.getLocation().getDimension() == sharedWorld.provider.getDimension()) {
                 TileEntity tile = sharedWorld.getTileEntity(n.getLocation().getPos());
@@ -279,12 +273,12 @@ public final class NodeHelper {
             }
         }
     }
-    
+
     public static void damageEntitiesFromTransaction(Deque<IImpetusNode> path, long energy) {
         damageEntitiesFromTransaction(path, (node, entity) -> ImpetusAPI.causeImpetusDamage(node.getLocation().getDimension() == entity.dimension ?
                 new Vec3d(node.getLocation().getPos()) : null, entity, Math.max(energy / 10.0F, 1.0F)));
     }
-    
+
     public static void damageEntitiesFromTransaction(Deque<IImpetusNode> path, BiConsumer<IImpetusNode, Entity> damageFunc) {
         if (path.size() >= 2) {
             Iterator<IImpetusNode> iterator = path.iterator();
@@ -299,47 +293,47 @@ public final class NodeHelper {
                             damageFunc.accept(first, e);
                     }
                 }
-                
+
                 first = second;
             }
         }
     }
-    
+
     public static void syncImpetusTransaction(Deque<IImpetusNode> path) {
         TAInternals.syncImpetusTransaction(path);
     }
-    
+
     public static void syncAllImpetusTransactions(Collection<Deque<IImpetusNode>> paths) {
         for (Deque<IImpetusNode> path : paths)
             TAInternals.syncImpetusTransaction(path);
     }
-    
+
     public static void syncImpetusNodeFully(IImpetusNode node) {
         TAInternals.fullySyncImpetusNode(node);
     }
-    
+
     public static void syncAddedImpetusNodeInput(IImpetusNode node, DimensionalBlockPos input) {
         TAInternals.updateImpetusNode(node, input, false, false);
     }
-    
+
     public static void syncAddedImpetusNodeOutput(IImpetusNode node, DimensionalBlockPos output) {
         TAInternals.updateImpetusNode(node, output, true, false);
     }
-    
+
     public static void syncRemovedImpetusNodeInput(IImpetusNode node, DimensionalBlockPos input) {
         TAInternals.updateImpetusNode(node, input, false, true);
     }
-    
+
     public static void syncRemovedImpetusNodeOutput(IImpetusNode node, DimensionalBlockPos output) {
         TAInternals.updateImpetusNode(node, output, true, true);
     }
-    
+
     public static void syncDestroyedImpetusNode(IImpetusNode node) {
         for (IImpetusNode n : node.getInputs())
             NodeHelper.syncRemovedImpetusNodeOutput(n, node.getLocation());
-        
+
         for (IImpetusNode n : node.getOutputs())
             NodeHelper.syncRemovedImpetusNodeInput(n, node.getLocation());
     }
-    
+
 }

--- a/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/NodeHelper.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/NodeHelper.java
@@ -242,11 +242,12 @@ public final class NodeHelper {
     
     public static void validateOutputs(World sharedWorld, IImpetusNode node) {
         HashSet<IImpetusNode> changed = new HashSet<>();
-        for (IImpetusNode output : node.getOutputs()) {
-            if (node.hasUnloadedNodes()) {
-                node.tryConnectUnloadedNodes(sharedWorld);
-            }
 
+        if (node.hasUnloadedNodes()) {
+            node.tryConnectUnloadedNodes(sharedWorld);
+        }
+
+        for (IImpetusNode output : node.getOutputs()) {
             if (sharedWorld.provider.getDimension() == node.getLocation().getDimension() &&
                     sharedWorld.provider.getDimension() == output.getLocation().getDimension()) {
                 

--- a/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/NodeHelper.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/NodeHelper.java
@@ -249,7 +249,7 @@ public final class NodeHelper {
                     if (te != null) {
                         IImpetusNode possible = te.getCapability(CapabilityImpetusNode.IMPETUS_NODE, null);
                         if (possible != null) {
-                            node.addInput(possible);
+                            node.addOutput(possible);
                             continue;
                         }
                     }

--- a/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/NodeHelper.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/NodeHelper.java
@@ -243,7 +243,7 @@ public final class NodeHelper {
     public static void validateOutputs(World sharedWorld, IImpetusNode node) {
         HashSet<IImpetusNode> changed = new HashSet<>();
         for (IImpetusNode output : node.getOutputs()) {
-            node.shouldTryToReConnect(sharedWorld);
+            node.hasUnloadedNodes(sharedWorld);
             if (sharedWorld.provider.getDimension() == node.getLocation().getDimension() &&
                     sharedWorld.provider.getDimension() == output.getLocation().getDimension()) {
                 

--- a/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/prefab/ImpetusNode.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/prefab/ImpetusNode.java
@@ -272,7 +272,7 @@ public class ImpetusNode implements IImpetusNode, INBTSerializable<NBTTagCompoun
     protected void initServer() {
         for (DimensionalBlockPos pos : inputs) {
             World world = DimensionManager.getWorld(pos.getDimension());
-            if (world != null && world.provider.getDimension() == pos.getDimension() && world.isBlockLoaded(pos.getPos())) {
+            if (world != null && world.provider.getDimension() == pos.getDimension()) {
                 TileEntity te = world.getTileEntity(pos.getPos());
                 if (te != null) {
                     IImpetusNode possible = te.getCapability(CapabilityImpetusNode.IMPETUS_NODE, null);
@@ -284,7 +284,7 @@ public class ImpetusNode implements IImpetusNode, INBTSerializable<NBTTagCompoun
         
         for (DimensionalBlockPos pos : outputs) {
             World world = DimensionManager.getWorld(pos.getDimension());
-            if (world != null && world.provider.getDimension() == pos.getDimension() && world.isBlockLoaded(pos.getPos())) {
+            if (world != null && world.provider.getDimension() == pos.getDimension()) {
                 TileEntity te = world.getTileEntity(pos.getPos());
                 if (te != null) {
                     IImpetusNode possible = te.getCapability(CapabilityImpetusNode.IMPETUS_NODE, null);
@@ -297,7 +297,7 @@ public class ImpetusNode implements IImpetusNode, INBTSerializable<NBTTagCompoun
     
     protected void initClient(World world) {
         for (DimensionalBlockPos pos : inputs) {
-            if (world.provider.getDimension() == pos.getDimension() && world.isBlockLoaded(pos.getPos())) {
+            if (world.provider.getDimension() == pos.getDimension()) {
                 TileEntity te = world.getTileEntity(pos.getPos());
                 if (te != null) {
                     IImpetusNode possible = te.getCapability(CapabilityImpetusNode.IMPETUS_NODE, null);
@@ -308,7 +308,7 @@ public class ImpetusNode implements IImpetusNode, INBTSerializable<NBTTagCompoun
         }
         
         for (DimensionalBlockPos pos : outputs) {
-            if (world.provider.getDimension() == pos.getDimension() && world.isBlockLoaded(pos.getPos())) {
+            if (world.provider.getDimension() == pos.getDimension()) {
                 TileEntity te = world.getTileEntity(pos.getPos());
                 if (te != null) {
                     IImpetusNode possible = te.getCapability(CapabilityImpetusNode.IMPETUS_NODE, null);

--- a/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/prefab/ImpetusNode.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/prefab/ImpetusNode.java
@@ -1,28 +1,26 @@
 /**
- *  Thaumic Augmentation
- *  Copyright (c) 2019 TheCodex6824.
- *
- *  This file is part of Thaumic Augmentation.
- *
- *  Thaumic Augmentation is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Lesser General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Thaumic Augmentation is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with Thaumic Augmentation.  If not, see <https://www.gnu.org/licenses/>.
+ * Thaumic Augmentation
+ * Copyright (c) 2019 TheCodex6824.
+ * <p>
+ * This file is part of Thaumic Augmentation.
+ * <p>
+ * Thaumic Augmentation is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * Thaumic Augmentation is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Thaumic Augmentation.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package thecodex6824.thaumicaugmentation.api.impetus.node.prefab;
 
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import net.minecraft.nbt.NBTTagCompound;
@@ -40,18 +38,20 @@ import thecodex6824.thaumicaugmentation.api.impetus.node.IImpetusNode;
 import thecodex6824.thaumicaugmentation.api.util.DimensionalBlockPos;
 
 public class ImpetusNode implements IImpetusNode, INBTSerializable<NBTTagCompound> {
-    
+
     protected IImpetusGraph graph;
     protected int maxInputs;
     protected int maxOutputs;
     protected DimensionalBlockPos loc;
     protected Set<DimensionalBlockPos> inputs;
     protected Set<DimensionalBlockPos> outputs;
-    
+
+    private boolean hasUnloadedNodes;
+
     public ImpetusNode(int totalInputs, int totalOutputs) {
         this(totalInputs, totalOutputs, DimensionalBlockPos.INVALID);
     }
-    
+
     public ImpetusNode(int totalInputs, int totalOutputs, DimensionalBlockPos location) {
         maxInputs = totalInputs;
         maxOutputs = totalOutputs;
@@ -62,47 +62,47 @@ public class ImpetusNode implements IImpetusNode, INBTSerializable<NBTTagCompoun
         if (!loc.isInvalid())
             graph.addNode(this);
     }
-    
+
     @Override
     public IImpetusGraph getGraph() {
         return graph;
     }
-    
+
     @Override
     public void setGraph(IImpetusGraph newGraph) {
         graph = newGraph;
     }
-    
+
     @Override
     public int getNumInputs() {
         return inputs.size();
     }
-    
+
     @Override
     public int getNumOutputs() {
         return outputs.size();
     }
-    
+
     @Override
     public int getMaxInputs() {
         return maxInputs;
     }
-    
+
     @Override
     public int getMaxOutputs() {
         return maxOutputs;
     }
-    
+
     @Override
     public boolean hasInput(IImpetusNode in) {
         return inputs.contains(in.getLocation());
     }
-    
+
     @Override
     public boolean hasOutput(IImpetusNode out) {
         return outputs.contains(out.getLocation());
     }
-    
+
     @Override
     public boolean addInput(IImpetusNode input) {
         boolean newToUs = addInputLocation(input.getLocation());
@@ -112,10 +112,10 @@ public class ImpetusNode implements IImpetusNode, INBTSerializable<NBTTagCompoun
             onConnected(input);
         if (newToThem || result)
             input.onConnected(this);
-        
+
         return result;
     }
-    
+
     @Override
     public boolean addOutput(IImpetusNode output) {
         boolean newToUs = addOutputLocation(output.getLocation());
@@ -125,10 +125,10 @@ public class ImpetusNode implements IImpetusNode, INBTSerializable<NBTTagCompoun
             onConnected(output);
         if (newToThem || result)
             output.onConnected(this);
-        
+
         return result;
     }
-    
+
     @Override
     public boolean removeInput(IImpetusNode input) {
         boolean removedUs = input.removeOutputLocation(loc);
@@ -137,10 +137,10 @@ public class ImpetusNode implements IImpetusNode, INBTSerializable<NBTTagCompoun
             onDisconnected(input);
         if (removedThem)
             input.onDisconnected(this);
-        
+
         return removedThem;
     }
-    
+
     @Override
     public boolean removeOutput(IImpetusNode output) {
         boolean removedUs = output.removeInputLocation(loc);
@@ -149,176 +149,206 @@ public class ImpetusNode implements IImpetusNode, INBTSerializable<NBTTagCompoun
             onDisconnected(output);
         if (removedThem)
             output.onDisconnected(this);
-        
+
         return removedThem;
     }
-    
+
     @Override
     public boolean canConnectNodeAsInput(IImpetusNode toConnect) {
         return true;
     }
-    
+
     @Override
     public boolean canConnectNodeAsOutput(IImpetusNode toConnect) {
         return true;
     }
-    
+
     @Override
     public boolean canRemoveNodeAsInput(IImpetusNode toRemove) {
         return true;
     }
-    
+
     @Override
     public boolean canRemoveNodeAsOutput(IImpetusNode toRemove) {
         return true;
     }
-    
+
     @Override
     public double getMaxConnectDistance(IImpetusNode toConnect) {
         return 8.0;
     }
-    
+
     @Override
     public boolean addInputLocation(DimensionalBlockPos toConnect) {
         if (inputs.size() == maxInputs && !inputs.contains(toConnect))
             throw new IndexOutOfBoundsException("Exceeded maximum amount of inputs for node (" + inputs.size() + ")");
-        
+
         return inputs.add(toConnect);
     }
-    
+
     @Override
     public boolean addOutputLocation(DimensionalBlockPos toConnect) {
         if (outputs.size() == maxOutputs && !outputs.contains(toConnect))
             throw new IndexOutOfBoundsException("Exceeded maximum amount of outputs for node (" + outputs.size() + ")");
-        
+
         return outputs.add(toConnect);
     }
-    
+
     @Override
     public boolean removeInputLocation(DimensionalBlockPos toRemove) {
         return inputs.remove(toRemove);
     }
-    
+
     @Override
     public boolean removeOutputLocation(DimensionalBlockPos toRemove) {
         return outputs.remove(toRemove);
     }
-    
+
     @Override
     public Set<DimensionalBlockPos> getInputLocations() {
         return inputs;
     }
-    
+
     @Override
     public Set<DimensionalBlockPos> getOutputLocations() {
         return outputs;
     }
-    
+
     @Override
     public Set<IImpetusNode> getInputs() {
         return inputs.stream().map(loc -> graph.findNodeByPosition(loc)).filter(Objects::nonNull).collect(Collectors.toSet());
     }
-    
+
     @Override
     public Set<IImpetusNode> getOutputs() {
         return outputs.stream().map(loc -> graph.findNodeByPosition(loc)).filter(Objects::nonNull).collect(Collectors.toSet());
     }
-    
+
     @Override
     public DimensionalBlockPos getLocation() {
         return loc;
     }
-    
+
     @Override
     public void setLocation(DimensionalBlockPos location) {
         if (!loc.isInvalid())
             graph.removeNode(this);
-        
+
         loc = location;
         graph.addNode(this);
     }
-    
+
     @Override
     public Vec3d getBeamEndpoint() {
         return new Vec3d(loc.getPos().getX() + 0.5, loc.getPos().getY() + 0.5, loc.getPos().getZ() + 0.5);
     }
-    
+
     @Override
     public boolean shouldPhysicalBeamLinkTo(IImpetusNode other) {
         return true;
     }
-    
+
     @Override
     public boolean shouldEnforceBeamLimitsWith(IImpetusNode other) {
         return true;
     }
-    
+
     @Override
     public void unload() {
         graph.removeNode(this);
     }
-    
+
     @Override
     public void destroy() {
         for (IImpetusNode node : graph.getInputs(this))
             removeInput(node);
-            
+
         for (IImpetusNode node : graph.getOutputs(this))
             removeOutput(node);
-        
+
         unload();
     }
-    
+
+    @Override
+    public void shouldTryToReConnect(World world) {
+        if (!hasUnloadedNodes) {
+            return;
+        }
+        List<Boolean> checks = new ArrayList<>();
+        for (DimensionalBlockPos pos : inputs) {
+            checks.add(validateNodeInput(world, pos));
+        }
+        for (DimensionalBlockPos pos : outputs) {
+            checks.add(validateNodeOutput(world, pos));
+        }
+
+        if (!checks.contains(false)) {
+            hasUnloadedNodes = false;
+        }
+    }
+
+    private boolean validateNodeInput(World world, DimensionalBlockPos pos) {
+        if (world.provider.getDimension() == pos.getDimension()) {
+            TileEntity te = world.getTileEntity(pos.getPos());
+            if (te != null) {
+                IImpetusNode possible = te.getCapability(CapabilityImpetusNode.IMPETUS_NODE, null);
+                if (possible != null) {
+                    if (world.isBlockLoaded(pos.getPos())) {
+                        addInput(possible);
+                        return true;
+                    }
+                    hasUnloadedNodes = true;
+                    return false;
+                }
+            }
+        }
+        //remove pos if tile is null or tile dos not have IMPETUS_NODE capability
+        outputs.remove(pos);
+        return false;
+    }
+
+    private boolean validateNodeOutput(World world, DimensionalBlockPos pos) {
+        if (world.provider.getDimension() == pos.getDimension()) {
+            TileEntity te = world.getTileEntity(pos.getPos());
+            if (te != null) {
+                IImpetusNode possible = te.getCapability(CapabilityImpetusNode.IMPETUS_NODE, null);
+                if (possible != null) {
+                    if (world.isBlockLoaded(pos.getPos())) {
+                        addOutput(possible);
+                        return true;
+                    }
+                    hasUnloadedNodes = true;
+                    return false;
+                }
+            }
+        }
+        //remove pos if tile is null or tile dos not have IMPETUS_NODE capability
+        outputs.remove(pos);
+        return false;
+    }
+
     protected void initServer() {
         for (DimensionalBlockPos pos : inputs) {
             World world = DimensionManager.getWorld(pos.getDimension());
-            if (world != null && world.provider.getDimension() == pos.getDimension()) {
-                TileEntity te = world.getTileEntity(pos.getPos());
-                if (te != null) {
-                    IImpetusNode possible = te.getCapability(CapabilityImpetusNode.IMPETUS_NODE, null);
-                    if (possible != null)
-                        addInput(possible);
-                }
-            }
+            validateNodeInput(world, pos);
         }
-        
+
         for (DimensionalBlockPos pos : outputs) {
             World world = DimensionManager.getWorld(pos.getDimension());
-            if (world != null && world.provider.getDimension() == pos.getDimension()) {
-                TileEntity te = world.getTileEntity(pos.getPos());
-                if (te != null) {
-                    IImpetusNode possible = te.getCapability(CapabilityImpetusNode.IMPETUS_NODE, null);
-                    if (possible != null)
-                        addOutput(possible);
-                }
-            }
+            validateNodeOutput(world, pos);
         }
     }
-    
+
     protected void initClient(World world) {
         for (DimensionalBlockPos pos : inputs) {
-            if (world.provider.getDimension() == pos.getDimension()) {
-                TileEntity te = world.getTileEntity(pos.getPos());
-                if (te != null) {
-                    IImpetusNode possible = te.getCapability(CapabilityImpetusNode.IMPETUS_NODE, null);
-                    if (possible != null)
-                        addInput(possible);
-                }
-            }
+            validateNodeInput(world, pos);
         }
-        
+
         for (DimensionalBlockPos pos : outputs) {
-            if (world.provider.getDimension() == pos.getDimension()) {
-                TileEntity te = world.getTileEntity(pos.getPos());
-                if (te != null) {
-                    IImpetusNode possible = te.getCapability(CapabilityImpetusNode.IMPETUS_NODE, null);
-                    if (possible != null)
-                        addOutput(possible);
-                }
-            }
+            validateNodeOutput(world, pos);
         }
     }
-    
+
     @Override
     public void init(World world) {
         if (!world.isRemote)
@@ -326,42 +356,42 @@ public class ImpetusNode implements IImpetusNode, INBTSerializable<NBTTagCompoun
         else
             initClient(world);
     }
-    
+
     @Override
     public NBTTagCompound getSyncNBT() {
         return serializeNBT();
     }
-    
+
     @Override
     public void readSyncNBT(NBTTagCompound tag) {
         deserializeNBT(tag);
     }
-    
+
     @Override
     public void deserializeNBT(NBTTagCompound nbt) {
         NBTTagList list = nbt.getTagList("inputs", NBT.TAG_INT_ARRAY);
         for (int i = 0; i < list.tagCount(); ++i)
             inputs.add(new DimensionalBlockPos(list.getIntArrayAt(i)));
-        
+
         list = nbt.getTagList("outputs", NBT.TAG_INT_ARRAY);
         for (int i = 0; i < list.tagCount(); ++i)
             outputs.add(new DimensionalBlockPos(list.getIntArrayAt(i)));
     }
-    
+
     @Override
     public NBTTagCompound serializeNBT() {
         NBTTagCompound tag = new NBTTagCompound();
         NBTTagList inputs = new NBTTagList();
         for (DimensionalBlockPos pos : this.inputs)
             inputs.appendTag(new NBTTagIntArray(pos.toArray()));
-        
+
         NBTTagList outputs = new NBTTagList();
         for (DimensionalBlockPos pos : this.outputs)
             outputs.appendTag(new NBTTagIntArray(pos.toArray()));
-        
+
         tag.setTag("inputs", inputs);
         tag.setTag("outputs", outputs);
         return tag;
     }
-    
+
 }

--- a/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/prefab/ImpetusNode.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/api/impetus/node/prefab/ImpetusNode.java
@@ -270,10 +270,11 @@ public class ImpetusNode implements IImpetusNode, INBTSerializable<NBTTagCompoun
     }
 
     @Override
-    public void shouldTryToReConnect(World world) {
+    public boolean hasUnloadedNodes(World world) {
         if (!hasUnloadedNodes) {
-            return;
+            return false;
         }
+
         List<Boolean> checks = new ArrayList<>();
         for (DimensionalBlockPos pos : inputs) {
             checks.add(validateNodeInput(world, pos));
@@ -284,7 +285,9 @@ public class ImpetusNode implements IImpetusNode, INBTSerializable<NBTTagCompoun
 
         if (!checks.contains(false)) {
             hasUnloadedNodes = false;
+            return false;
         }
+        return true;
     }
 
     private boolean validateNodeInput(World world, DimensionalBlockPos pos) {


### PR DESCRIPTION
The problem is that the blocks in another chunk might not be loaded by the time this function is called, but eater way you are validating the links once the tile starts ticking. This fix might not be perfect, as i have only tested the impetus gates, drainer and generators

Should fix  #275
