### PR TITLE
More default addon support for disabled research

### DIFF
--- a/src/main/java/thecodex6824/thaumicaugmentation/common/TAConfigHolder.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/common/TAConfigHolder.java
@@ -595,7 +595,7 @@ public final class TAConfigHolder {
         public String[] deniedCategories = new String[] {
                 "THAUMIC_AUGMENTATION", "THAUMIC_TINKERER", "THAUMIC_WONDERS", "RUSTIC_THAUMATURGY", "PERIPHERY",
                 "ENGINEERED_GOLEMS", "EXPANDEDARCANUM", "MECHANICS", "APOCRYPHA", "ISORROPIA", "REVELATIONS", "WEMT",
-                "FORGOTTEN_RELICS", "WARPTHEORY"
+                "EWT", "WARFARE", "FORGOTTEN_RELICS", "WARPTHEORY", "MAGICBEES", "TCONEVO"
         };
 
         @Name("AllowWussRiftSeed")

--- a/src/main/java/thecodex6824/thaumicaugmentation/common/TAConfigHolder.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/common/TAConfigHolder.java
@@ -594,7 +594,8 @@ public final class TAConfigHolder {
         })
         public String[] deniedCategories = new String[] {
                 "THAUMIC_AUGMENTATION", "THAUMIC_TINKERER", "THAUMIC_WONDERS", "RUSTIC_THAUMATURGY", "PERIPHERY",
-                "ENGINEERED_GOLEMS", "EXPANDEDARCANUM", "MECHANICS"
+                "ENGINEERED_GOLEMS", "EXPANDEDARCANUM", "MECHANICS", "APOCRYPHA", "ISORROPIA", "REVELATIONS", "WEMT",
+                "FORGOTTEN_RELICS", "WARPTHEORY"
         };
 
         @Name("AllowWussRiftSeed")


### PR DESCRIPTION
Disables research categories for the following addons, as none of these use points from their categories:

- Crimson Warfare
- Electro-Magic Tools
- Enchanting With Thaumcraft
- Lost Magic/ReForbidden Magic (both use the exact same category)
- Magic Bees
- New Crimson Revelations
- ReForgotten Relics
- Thaumic Isorropia
- Tinkers' Evolution
- Warp Apocalypse