### PR TITLE
ScanEntityWithPeacefulFallback Null check

### DIFF
--- a/src/main/java/thecodex6824/thaumicaugmentation/common/research/ScanEntityWithPeacefulFallback.java
+++ b/src/main/java/thecodex6824/thaumicaugmentation/common/research/ScanEntityWithPeacefulFallback.java
@@ -39,10 +39,13 @@ public class ScanEntityWithPeacefulFallback implements IScanThing {
     
     @Override
     public boolean checkThing(EntityPlayer player, Object thing) {
-        if (player.getEntityWorld().getDifficulty() != EnumDifficulty.PEACEFUL)
-            return entity.checkThing(player, thing);
-        else
-            return fallback.checkThing(player, thing);
+        if (player != null && thing != null) {
+            if (player.getEntityWorld().getDifficulty() != EnumDifficulty.PEACEFUL)
+                return entity.checkThing(player, thing);
+            else
+                return fallback.checkThing(player, thing);
+        }
+        return false;
     }
     
     @Override


### PR DESCRIPTION
Adds a simple null check to ScanEntityWithPeacefulFallback to fix #390 most likely could be fixed on TC4 Research Port's end but it's easier to fix it here, and I can't think of any situations that this would break anything.